### PR TITLE
Clear Router Cache on Form Submit

### DIFF
--- a/app/components/ContactForm/ContactForm.tsx
+++ b/app/components/ContactForm/ContactForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PropsWithChildren, useCallback, useEffect } from "react";
+import { PropsWithChildren, useCallback } from "react";
 import { useFormState } from "react-dom";
 import { useRouter } from "next/navigation";
 

--- a/app/components/ContactForm/ContactForm.tsx
+++ b/app/components/ContactForm/ContactForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { PropsWithChildren, useCallback } from "react";
+import { PropsWithChildren, useCallback, useEffect } from "react";
 import { useFormState } from "react-dom";
+import { useRouter } from "next/navigation";
 
 import { contactAction } from "~/components/ContactForm/contact-action";
 import Button from "~components/Button/Button";
@@ -22,6 +23,8 @@ interface Label extends PropsWithChildren {
 }
 
 const ContactForm = () => {
+  const router = useRouter();
+
   const [state, formAction] = useFormState(contactAction, {
     errors: [],
     message: "",
@@ -46,6 +49,10 @@ const ContactForm = () => {
   const phoneErrors = findErrors("phone");
   const messageErrors = findErrors("message");
   const honeyPotErrors = findErrors("website");
+
+  useEffect(() => {
+    router.refresh();
+  }, [state?.status, router]);
 
   if (state?.status === 201) return <SuccessMessage />;
 

--- a/app/components/ContactForm/ContactForm.tsx
+++ b/app/components/ContactForm/ContactForm.tsx
@@ -50,9 +50,10 @@ const ContactForm = () => {
   const messageErrors = findErrors("message");
   const honeyPotErrors = findErrors("website");
 
-  useEffect(() => {
+  const handleSubmit = (data: FormData) => {
+    formAction(data);
     router.refresh();
-  }, [state?.status, router]);
+  };
 
   if (state?.status === 201) return <SuccessMessage />;
 
@@ -74,7 +75,7 @@ const ContactForm = () => {
         </a>
         &nbsp;and drop me a line. Talk soon! 👋🏽
       </p>
-      <form action={formAction} className="flex flex-col gap-6">
+      <form action={handleSubmit} className="flex flex-col gap-6">
         <section className="flex gap-5 flex-col md:flex-row">
           <TextInput
             name="First Name"


### PR DESCRIPTION
**Description**
- The contact form only fires its associated actions (sending outbound emails and pushing to the data store) if a page is refreshed or that same route is next visited.

**Expected Behavior**
- The contact form should send emails and save to the data store immediately after a valid submission is processed.

**Actual Behavior**
- The contact form only sends emails and saves data if a page is refreshed or that same route is next visited.
- This behavior is consistent with the Next.js `revalidatePath()` functionality (which is currently called on `app/components/ContactForm/contact-action.ts`). 
  - "`revalidatePath` only invalidates the cache when the included path is next visited. This means calling revalidatePath with a dynamic route segment will not immediately trigger many revalidations at once. The invalidation only happens when the path is next visited." https://nextjs.org/docs/app/api-reference/functions/revalidatePath
