### PR TITLE
Fix Storybook Deployments

### DIFF
--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -1,7 +1,10 @@
+name: Build and Publish Storybook to GitHub Pages
+
 on:
   push:
     branches:
-      - "main"
+    # Change to "main" when pushing into the main branch
+      - "bugs/deploy-storybook"
 
 permissions:
   contents: read
@@ -9,18 +12,25 @@ permissions:
   id-token: write
 
 jobs:
-  deploy_storybook:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - id: build-publish
-        uses: bitovi/github-actions-storybook-to-github-pages@v1.0.2
+      - uses: actions/checkout@v4
         with:
-          env:
-            RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "25"
+      - name: Enable Yarn Corepack
+        run: corepack enable
+      - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
+        with:
+          env: RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
             EMAIL_SEND_NAME=${{ secrets.EMAIL_SEND_NAME }}
             EMAIL_ADMIN_ADDRESS=${{ secrets.EMAIL_ADMIN_ADDRESS }}
             SANITY_PROJECT_ID=${{ secrets.SANITY_PROJECT_ID }}
             SANITY_DATASET=${{ secrets.SANITY_DATASET }}
-          path: storybook-static
+          install_command: yarn install
           build_command: yarn build-storybook
-          install_command: corepack enable && yarn install
+          path: storybook-static
+          checkout: false

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -3,8 +3,7 @@ name: Build and Publish Storybook to GitHub Pages
 on:
   push:
     branches:
-    # Change to "main" when pushing into the main branch
-      - "bugs/deploy-storybook"
+      - "main"
 
 permissions:
   contents: read
@@ -25,11 +24,6 @@ jobs:
         run: corepack enable
       - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
         with:
-          env: RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
-            EMAIL_SEND_NAME=${{ secrets.EMAIL_SEND_NAME }}
-            EMAIL_ADMIN_ADDRESS=${{ secrets.EMAIL_ADMIN_ADDRESS }}
-            SANITY_PROJECT_ID=${{ secrets.SANITY_PROJECT_ID }}
-            SANITY_DATASET=${{ secrets.SANITY_DATASET }}
           install_command: yarn install
           build_command: yarn build-storybook
           path: storybook-static

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ next-env.d.ts
 
 # storybook
 debug-storybook.log
+storybook-static/

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -25,6 +25,7 @@ const config: StorybookConfig = {
         "~components": path.resolve(__dirname, "../app/components"),
         "~icon": path.resolve(__dirname, "../app/components/Icon"),
         "~logo": path.resolve(__dirname, "../app/components/Logo"),
+        "~utils": path.resolve(__dirname, "../app/utils"),
         "~assets": path.resolve(__dirname, "../public/assets"),
       };
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -41,6 +41,13 @@ const config: StorybookConfig = {
           resource.request = resource.request.replace(/^node:/, "");
         }),
       );
+
+      config.plugins.push(
+        new webpack.NormalModuleReplacementPlugin(
+          /ContactForm\/contact-action$/,
+          path.resolve(__dirname, "mocks/contact-action.ts"),
+        ),
+      );
     }
     return config;
   },

--- a/.storybook/mocks/contact-action.ts
+++ b/.storybook/mocks/contact-action.ts
@@ -1,0 +1,14 @@
+type ContactState = {
+  errors: unknown[];
+  message: string;
+  status: number;
+};
+
+export const contactAction = async (
+  _prevState: ContactState,
+  _params: FormData,
+): Promise<ContactState> => ({
+  errors: [],
+  message: "",
+  status: 200,
+});

--- a/app/(blog)/code-actions.ts
+++ b/app/(blog)/code-actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { fileToString } from "~/utils";
+import { fileToString } from "~/utils/server";
 
 const docTitle = async (title: string) => {
   const html = await fileToString("app/(blog)/filename.html");

--- a/app/(blog)/creatmoteo/[slug]/page.tsx
+++ b/app/(blog)/creatmoteo/[slug]/page.tsx
@@ -3,7 +3,8 @@ import type { Metadata } from "next";
 import PageHeader from "~components/PageHeader";
 import { getArticleBySlug, getAllSlugs } from "~/(blog)/sanity-actions";
 import ArticleBody from "~/(blog)/ArticleBody";
-import { authorsAsString, generateBlogMeta, formattedBlogDate } from "~/utils";
+import { authorsAsString, formattedBlogDate } from "~/utils";
+import { generateBlogMeta } from "~/utils/server";
 
 export default async function Article(props: {
   params: Promise<{ slug: string }>;

--- a/app/(blog)/journal/[slug]/page.tsx
+++ b/app/(blog)/journal/[slug]/page.tsx
@@ -3,7 +3,8 @@ import type { Metadata } from "next";
 import PageHeader from "~components/PageHeader";
 import { getArticleBySlug, getAllSlugs } from "~/(blog)/sanity-actions";
 import ArticleBody from "~/(blog)/ArticleBody";
-import { authorsAsString, generateBlogMeta, formattedBlogDate } from "~/utils";
+import { authorsAsString, formattedBlogDate } from "~/utils";
+import { generateBlogMeta } from "~/utils/server";
 
 export default async function Article(props: {
   params: Promise<{ slug: string }>;

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -1,7 +1,3 @@
-import { readFile } from "node:fs/promises";
-
-import { getArticleBySlug } from "~/(blog)/sanity-actions";
-
 type Author = {
   firstName: string;
   lastName: string;
@@ -12,25 +8,6 @@ export const colorSwitcher = (
   darkColor: string,
   lightColor: string,
 ) => (theme === "dark" ? darkColor : lightColor);
-
-export const fileToString = async (path: string) => readFile(path, "utf8");
-
-export const generateBlogMeta = async (slug: string, category: string) => {
-  const meta = await getArticleBySlug(slug, category);
-
-  return {
-    title: `${meta.title} | ${meta.authors.map((name: { firstName: string; lastName: string }) => `${name.firstName} ${name.lastName}`).join(", ")}`,
-    description: meta.metaDescription,
-    openGraph: {
-      images: { url: meta.featuredImage },
-    },
-    authors: meta.authors.map(
-      (author: { firstName: string; lastName: string }) => ({
-        name: `${author.firstName} ${author.lastName}`,
-      }),
-    ),
-  };
-};
 
 export const formattedBlogDate = (date: string | number | Date) => {
   return new Date(date).toLocaleDateString("en-US", {

--- a/app/utils/server.ts
+++ b/app/utils/server.ts
@@ -1,0 +1,22 @@
+import { readFile } from "node:fs/promises";
+
+import { getArticleBySlug } from "~/(blog)/sanity-actions";
+
+export const fileToString = async (path: string) => readFile(path, "utf8");
+
+export const generateBlogMeta = async (slug: string, category: string) => {
+  const meta = await getArticleBySlug(slug, category);
+
+  return {
+    title: `${meta.title} | ${meta.authors.map((name: { firstName: string; lastName: string }) => `${name.firstName} ${name.lastName}`).join(", ")}`,
+    description: meta.metaDescription,
+    openGraph: {
+      images: { url: meta.featuredImage },
+    },
+    authors: meta.authors.map(
+      (author: { firstName: string; lastName: string }) => ({
+        name: `${author.firstName} ${author.lastName}`,
+      }),
+    ),
+  };
+};

--- a/app/work/abate/page.tsx
+++ b/app/work/abate/page.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import PageHeader from "~components/PageHeader";
 import ViewLink from "~components/ViewLink/ViewLink";
 import CodeBlock from "~/components/Code/CodeBlock";
-import { fileToString } from "~/utils";
+import { fileToString } from "~/utils/server";
 import fullProcess from "~assets/images/case-study-abate.png";
 
 export const metadata: Metadata = {

--- a/app/work/webflow/page.tsx
+++ b/app/work/webflow/page.tsx
@@ -4,7 +4,7 @@ import PageHeader from "~components/PageHeader";
 import ViewLink from "~components/ViewLink/ViewLink";
 import InlineCode from "~/components/Code/InlineCode";
 import CodeBlock from "~/components/Code/CodeBlock";
-import { fileToString } from "~/utils";
+import { fileToString } from "~/utils/server";
 
 export const metadata: Metadata = {
   title: "Sunjay Armstead | Webflow AI Case Study",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
       "~logo/*": [
         "./app/components/Logo/*"
       ],
+       "~utils/*": [
+        "./app/utils/*"
+      ],
       "~assets/*": [
         "./public/assets/*"
       ]


### PR DESCRIPTION
The deployed Storybook is crashing on some stories with a "before initialization" error. The cause: server-only code (Sanity, Resend, Postgres) was leaking into the browser bundle, since Storybook doesn't apply Next.js's server/client split.

### Changes
- Bump `bitovi/github-actions-storybook-to-github-pages` version
- **Split `app/utils`** — moved server-only helpers into `utils/server.ts` so client components (ViewLink, Footer, etc.) no longer pull in server code. Fixes the `ViewLink` story.
- **Stubbed the contact server action** in Storybook config so `resend`/`@vercel/postgres` stay out of the client bundle. Fixes the `ContactForm` story.
- **Removed unused build secrets** from the deploy workflow (none are referenced in the Storybook build).